### PR TITLE
Joke 419 - typo fix - Fourty Seven to Forty Seven - Fourty is not the…

### DIFF
--- a/classes/ChuckAPI.inc.php
+++ b/classes/ChuckAPI.inc.php
@@ -159,7 +159,7 @@ class ChuckAPI {
 	 *	
 	 *	@param	$quote	Quote instance
 	 */
-	protected function echoExeption($e) {
+	protected function echoException($e) {
 		echo('{ "type": "' . get_class($e) . '", "value": "' . $e->getMessage() . '"' . $this->getDebugJSON() . ' }');	
 	}
 

--- a/classes/ChuckDatabaseFiller.inc.php
+++ b/classes/ChuckDatabaseFiller.inc.php
@@ -411,7 +411,7 @@ class ChuckDatabaseFiller {
     $db->addJoke(new Quote(416, "%firstName% %lastName% plays racquetball with a waffle iron and a bowling ball.", array()));
     $db->addJoke(new Quote(417, "According to the Bible, God created the universe in six days. Before that, %firstName% %lastName% created God by snapping his fingers.", array()));
     $db->addJoke(new Quote(418, "%firstName% %lastName% doesn't believe in ravioli. He stuffs a live turtle with beef and smothers it in pig's blood.", array()));
-    $db->addJoke(new Quote(419, "Count from one to ten. That's how long it would take %firstName% %lastName% to kill you...Fourty seven times.", array()));
+    $db->addJoke(new Quote(419, "Count from one to ten. That's how long it would take %firstName% %lastName% to kill you...Forty seven times.", array()));
     $db->addJoke(new Quote(420, "The 1972 Miami Dolphins lost one game, it was a game vs. %firstName% %lastName% and three seven year old girls. %firstName% %lastName% won with a roundhouse-kick to the face in overtime.", array()));
     $db->addJoke(new Quote(421, "%firstName% %lastName% is not Politically Correct. He is just Correct. Always.", array()));
     $db->addJoke(new Quote(422, "Mr. T pities the fool. %firstName% %lastName% rips the fool's head off.", array()));

--- a/classes/ChuckDatabaseFiller.inc.php
+++ b/classes/ChuckDatabaseFiller.inc.php
@@ -403,7 +403,7 @@ class ChuckDatabaseFiller {
     $db->addJoke(new Quote(408, "Love does not hurt. %firstName% %lastName% does.", array()));
     $db->addJoke(new Quote(409, "The term \"Cleveland Steamer\" got its name from %firstName% %lastName%, when he took a dump while visiting the Rock and Roll Hall of fame and buried northern Ohio under a glacier of fecal matter.", array()));
     $db->addJoke(new Quote(410, "%firstName% %lastName% once round-house kicked a salesman. Over the phone.", array()));
-    $db->addJoke(new Quote(411, "The pen is mighter than the sword, but only if the pen is held by %firstName% %lastName%.", array()));
+    $db->addJoke(new Quote(411, "The pen is mightier than the sword, but only if the pen is held by %firstName% %lastName%.", array()));
     $db->addJoke(new Quote(412, "%firstName% %lastName% knows the last digit of pi.", array($nerdy)));
     $db->addJoke(new Quote(413, "Those aren't credits that roll after Walker Texas Ranger. It is actually a list of fatalities that occurred during the making of the episode.", array()));
     $db->addJoke(new Quote(414, "The air around %firstName% %lastName% is always a balmy 78 degrees.", array()));

--- a/classes/ChuckScriptCommunicationAPI.inc.php
+++ b/classes/ChuckScriptCommunicationAPI.inc.php
@@ -51,7 +51,7 @@ class ChuckScriptCommunicationAPI extends ChuckAPI {
 	 *	
 	 *	@param	$quote	Quote instance
 	 */
-	protected function echoExeption($e) {
+	protected function echoException($e) {
 		echo('(function() { ' . $this->callback . '({ "type": "' . get_class($e) . '", "value": "' . $e->getMessage() . '" }); })();');	
 	}
 


### PR DESCRIPTION
Correction for the spelling of 47 which is `Forty Seven` & not `Fourty Seven`
It might sound trivial - but why not keep everything as perfect as possible